### PR TITLE
support requests with content type application/json

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -15,16 +15,27 @@ socket.on('proxy', function (data) {
 
 $('body').on('click', '.js-resend', function( event ){
   event.preventDefault();
-  var data = $(this).data('json')
-  proxy( data, port.value );
+  var data = $(this).data('json');
+  var contentType = $(this).data('content-type');
+  proxy( data, port.value, contentType );
 })
 
-var proxy = function proxy( payload, port ){
+var proxy = function proxy( payload, port, contentType ){
+  if (contentType && contentType.indexOf('application/json') === 0) {
+    // if request was sent as JSON, forward it as same content type
+    payload = JSON.stringify(payload);
+    headers = {
+      'content-type': contentType
+    };
+  } else {
+    headers = {};
+  }
   $.ajax({
     type: "POST",
     async: true,
     data: payload,
-    url: 'http://localhost:' + port
+    url: 'http://localhost:' + port,
+    headers: headers
   });
 }
 
@@ -47,7 +58,7 @@ if( slug != "" ){
     });
   }
 } else {
- var apts = Appointment.all().reverse(); 
+ var apts = Appointment.all().reverse();
  if( apts.length ){
    $(".recent").show();
  }
@@ -83,7 +94,7 @@ $('.js-test-connection').on('click', function( e ){
     success: function(message,text,response){
       $res.attr('data-status','success')
       $res.html( "Ok" ).append( $remove );
-    }, 
+    },
     error: function( xhr, status, err ){
       $res.attr('data-status','error')
       if( xhr.readyState == 0 ){

--- a/views/request.html
+++ b/views/request.html
@@ -4,7 +4,9 @@
       <small>
 	<abbr class="js-timeago" title="{{this.createdAt}}">{{this.createdAt}}</abbr>
       </small>
-      <a href='#' class='show-if-proxy js-resend' data-json="{{json this.payload}}">Resend to Localhost</a>
+      <a href='#' class='show-if-proxy js-resend'
+        data-json="{{json this.payload}}"
+        data-content-type="{{this.headers.content-type}}">Resend to Localhost</a>
     </div>
     <div class='headers'>
       <h3>Headers</h3>


### PR DESCRIPTION
This is a great tool and really useful to me! Thanks for that.

A webhook I was using sent me a POST request with content type ```application/json```, but the proxy to localhost function of this tool forwards requests with ```application/x-www-form-urlencoded```. This PR reads the content type of the incoming request and forwards it to localhost in the corresponding format if it is JSON data.

Hope this helps!